### PR TITLE
readDirRecurse: optionally ignore hidden files/directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function readDirRecurse (rootDir: string, ignoreHidden: ?boolean): Promise {
     const fileEntries = []
     const options = {}
     if (ignoreHidden) {
-      options['filter'] = filterHidden
+      options.filter = filterHidden
     }
     klaw(rootDir, options)
       .on('data', (item) => {

--- a/test/fixtures/.d/e.txt
+++ b/test/fixtures/.d/e.txt
@@ -1,0 +1,1 @@
+Hello from hidden directory!

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,11 @@ test('index: create zip file', async (t) => {
   }
 
   const zipper = new Zip(zipfile, { level: 1 })
-  await zipper.addDir('test/fixtures')
+  await zipper.addDir('test/fixtures', 'test/fixtures', true)
   const written = await zipper.finalize()
   t.pass(written + ' total bytes written')
+
+  await zipper.addDir('test/fixtures/.d', 'test/fixtures/.d', false)
+  const hiddenWritten = await zipper.finalize()
+  t.pass(hiddenWritten + ' total bytes written')
 })


### PR DESCRIPTION
Added a new argument `ignoreHidden` to `readDirRecurse`, which allows callers to skip hidden files in the exported zip file.