### PR TITLE
Improve tests to inspect and verify zipfile contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,13 +130,15 @@ export default class Zip {
       throw Error('no files in zip!')
     }
 
-    this._pushCentralDirectory()
-    const outStream = fs.createWriteStream(this.zipFileName)
-    for (let buf of this.queue) {
-      outStream.write(buf)
-    }
-    outStream.end()
-    return this.fileptr
+    return new Promise((resolve, reject) => {
+      this._pushCentralDirectory()
+      const outStream = fs.createWriteStream(this.zipFileName)
+      for (let buf of this.queue) {
+        outStream.write(buf)
+      }
+      outStream.on('finish', () => resolve(this.fileptr))
+      outStream.end()
+    })
   }
 
   // Internal method to create and output the local file header.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "rollup-plugin-flow": "^1.1.1",
     "standard": "^11.0.1",
     "tape": "^4.9.0",
-    "tape-promise": "^3.0.0"
+    "tape-promise": "^4.0.0"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/ExodusMovement/zip-up.git"
   },
-  "files": [
-  ],
+  "files": [],
   "scripts": {
     "build": "rollup -c",
     "prepublishOnly": "npm test",
@@ -28,6 +27,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.2.6",
+    "node-stream-zip": "^1.8.2",
     "rollup": "^0.58.2",
     "rollup-plugin-flow": "^1.1.1",
     "standard": "^11.0.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,30 +1,62 @@
-// @flow
 const test = require('tape-promise/tape')
 const fs = require('fs-extra')
+const Unzip = require('node-stream-zip')
+
 const Zip = require('../bundle')
 
 test('index: create zip file', async (t) => {
-  const zipfile = 'test/output.zip'
+  const zipfile = './test/output.zip'
 
-  t.pass('Reading directories "fixtures"')
+  t.pass('Reading directory "fixtures"')
 
-  try {
-    fs.unlinkSync(zipfile)
-  } catch (err) {
-    // Ignore if not found
-    //
-    if (err.code !== 'ENOENT') {
-      console.error(err)
-      throw err
+  async function createZip () {
+    if (await fs.exists(zipfile)) {
+      await t.doesNotReject(fs.unlink(zipfile), null, 'zipfile unlinks')
     }
+    return new Zip(zipfile, { level: 1 })
   }
 
-  const zipper = new Zip(zipfile, { level: 1 })
-  await zipper.addDir('test/fixtures', 'test/fixtures', true)
-  const written = await zipper.finalize()
-  t.pass(written + ' total bytes written')
+  function createUnzip () {
+    return new Promise((resolve, reject) => {
+      const unzip = new Unzip({
+        file: zipfile,
+        storeEntries: true,
+        skipEntryNameValidation: true // if there are backslashes, ignore them
+      })
 
-  await zipper.addDir('test/fixtures/.d', 'test/fixtures/.d', false)
-  const hiddenWritten = await zipper.finalize()
-  t.pass(hiddenWritten + ' total bytes written')
+      unzip.on('error', (err) => {
+        console.log('error found!')
+        console.error(err)
+        reject(err)
+      })
+
+      unzip.on('ready', async () => {
+        resolve(unzip)
+      })
+    })
+  }
+
+  const zipper = await createZip()
+
+  t.test('zip fixtures, no hidden dir', async (t) => {
+    await zipper.addDir('test/fixtures', 'test/fixtures', true /* ignoreHidden */)
+    const written = await zipper.finalize()
+    t.pass(written + ' total bytes written')
+
+    const unzip = await createUnzip()
+    const files = Object.keys(unzip.entries()).sort()
+    t.deepEqual(files, ['test/fixtures/a.txt', 'test/fixtures/b/c.txt'], 'should be no hidden folder')
+    t.end()
+  })
+
+  t.test('zip fixtures with hidden dir', async (t) => {
+    await zipper.addDir('test/fixtures/.d', 'test/fixtures/.d', false /* ignoreHidden */)
+    const hiddenWritten = await zipper.finalize()
+    t.pass(hiddenWritten + ' total bytes written')
+
+    const unzip = await createUnzip()
+    const files = Object.keys(unzip.entries()).sort()
+    t.deepEqual(files, ['test/fixtures/.d/e.txt', 'test/fixtures/a.txt', 'test/fixtures/b/c.txt'], 'all files including hidden folder')
+    t.end()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+node-stream-zip@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.8.2.tgz#1f79e30ab3ff54cbda312cd3a9f0030b15bb3f53"
+  integrity sha512-zwP2F/R28Oqtl0gOLItk5QjJ6jEU8XO4kaUMgeqvCyXPgdCZlm8T/5qLMiNy+moJCBCiMQAaX7aVMRhT0t2vkQ==
+
 normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,9 +1389,10 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tape-promise@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/tape-promise/-/tape-promise-3.0.0.tgz#ffb864cc41df54f0ce0dffbb642c0e3e9f2c786f"
+tape-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tape-promise/-/tape-promise-4.0.0.tgz#c1f3553959b2e9d64b1546e7276b8a017c616897"
+  integrity sha512-mNi5yhWAKDuNgZCfFKeZbsXvraVOf+I8UZG+lf+aoRrzX4+jd4mpNBjYh16/VcpEMUtS0iFndBgnfxxZbtyLFw==
   dependencies:
     is-promise "^2.1.0"
     onetime "^2.0.0"


### PR DESCRIPTION
Closes #10.

Also fixes a bug where the zip file was not being fully finalized. This became obvious when trying to read the zip file after finalization in the test.